### PR TITLE
Port perspectiveFromFieldOfView from gl-matrix dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ var scale = require('gl-mat4/scale')
   - [multiply()](#multiplyoutmat4-amat4-bmat4)
   - [ortho()](#orthooutmat4-leftnumber-rightnumber-bottomnumber-topnumber-nearnumber-farnumber)
   - [perspective()](#perspectiveoutmat4-fovynumber-aspectnumber-nearnumber-farnumber)
+  - [perspectiveFromFieldOfView()](#perspectiveFromFieldOfViewoutmat4-fovobject-nearnumber-farnumber)
   - [rotate()](#rotateoutmat4-amat4-radnumber-axisvec3)
   - [rotateX()](#rotatexoutmat4-amat4-radnumber)
   - [rotateY()](#rotateyoutmat4-amat4-radnumber)
@@ -110,6 +111,10 @@ var scale = require('gl-mat4/scale')
 ## perspective(out:mat4, fovy:number, aspect:number, near:number, far:number)
 
   Generates a perspective projection matrix with the given bounds
+
+## perspectiveFromFieldOfView(out:mat4, fov:object, near:number, far:number)
+
+  Generates a perspective projection matrix with the given field of view.
 
 ## rotate(out:mat4, a:mat4, rad:Number, axis:vec3)
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = {
   , fromQuat: require('./fromQuat')
   , frustum: require('./frustum')
   , perspective: require('./perspective')
+  , perspectiveFromFieldOfView: require('./perspectiveFromFieldOfView')
   , ortho: require('./ortho')
   , lookAt: require('./lookAt')
   , str: require('./str')

--- a/perspectiveFromFieldOfView.js
+++ b/perspectiveFromFieldOfView.js
@@ -1,0 +1,40 @@
+module.exports = perspectiveFromFieldOfView;
+
+/**
+ * Generates a perspective projection matrix with the given field of view.
+ * This is primarily useful for generating projection matrices to be used
+ * with the still experiemental WebVR API.
+ *
+ * @param {mat4} out mat4 frustum matrix will be written into
+ * @param {number} fov Object containing the following values: upDegrees, downDegrees, leftDegrees, rightDegrees
+ * @param {number} near Near bound of the frustum
+ * @param {number} far Far bound of the frustum
+ * @returns {mat4} out
+ */
+function perspectiveFromFieldOfView(out, fov, near, far) {
+    var upTan = Math.tan(fov.upDegrees * Math.PI/180.0),
+        downTan = Math.tan(fov.downDegrees * Math.PI/180.0),
+        leftTan = Math.tan(fov.leftDegrees * Math.PI/180.0),
+        rightTan = Math.tan(fov.rightDegrees * Math.PI/180.0),
+        xScale = 2.0 / (leftTan + rightTan),
+        yScale = 2.0 / (upTan + downTan);
+
+    out[0] = xScale;
+    out[1] = 0.0;
+    out[2] = 0.0;
+    out[3] = 0.0;
+    out[4] = 0.0;
+    out[5] = yScale;
+    out[6] = 0.0;
+    out[7] = 0.0;
+    out[8] = -((leftTan - rightTan) * xScale * 0.5);
+    out[9] = ((upTan - downTan) * yScale * 0.5);
+    out[10] = far / (near - far);
+    out[11] = -1.0;
+    out[12] = 0.0;
+    out[13] = 0.0;
+    out[14] = (far * near) / (near - far);
+    out[15] = 0.0;
+    return out;
+}
+


### PR DESCRIPTION
Original commit:
toji/gl-matrix@955bb55a48e4a484304cc487638f4ef18d60cd00

> Added VR-oriented mat4.perspectiveFromFieldOfView
> 
> Generates a perspective matrix give a VRFieldOfView object from the
> (still experimental) WebVR API.
> toji authored on Sep 1, 2014
