### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,7 @@
     "vector",
     "maths"
   ],
-  "license": {
-    "type": "Zlib",
-    "url": "http://github.com/stackgl/gl-mat4/blob/master/LICENSE.md"
-  },
+  "license": "Zlib",
   "contributors": [
     "Brandon Jones <tojiro@gmail.com>",
     "Colin MacKenzie IV <sinisterchipmunk@gmail.com>"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
